### PR TITLE
Add HashBrown CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ for a curated list of packages and resources.
 * [Pencilblue](https://github.com/pencilblue/pencilblue) ([website](https://pencilblue.org/)) - Business Class Content Management.
 * [Apostrophe](https://github.com/punkave/apostrophe) ([website](http://apostrophecms.org/)) - Apostrophe is a CMS framework that supports in-context editing, schema-driven content types, flexible widgets, and much more.
 * [Cody](https://github.com/jcoppieters/cody/) ([website](http://howest.cody-cms.org/en/)) - Javascript Content Management System.
+* [HashBrown](https://github.com/Putaitu/hashbrown-cms/) ([website](http://hashbrown.rocks/)) - Remote, multilingual, multi-project, multi-environment CMS using customisable content and field schemas.
 
 ## Developers
 


### PR DESCRIPTION
This is our own CMS that we use for all of our customers, and we are currently planning a public beta for a cloud service.