### PR TITLE
Remove telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ for a curated list of packages and resources.
 * [Enduro.js](https://github.com/Gottwik/enduro) ([website](http://endurojs.com)) - Minimalistic, flat-file, full-fledged cms that gets your website running in minutes.
 * [Raneto](https://github.com/gilbitron/Raneto) ([website](http://raneto.com/)) - Markdown powered Knowledgebase for Nodejs
 
-**Meteor apps**
-* [TelescopeJS](https://github.com/TelescopeJS/Telescope) ([website](http://www.telescopeapp.org)) - Telescope Nova is a free, open-source app platform built with React and powered by Meteor on the back-end. Nova provides simple building blocks such as posts, comments, forms, and modals, and makes it easy to quickly customize them to build modern, social web apps.
-
-
 ## Developers
 
 * [Shield](https://github.com/badges/shields) ([website](http://shields.io/)) - Shields badge specification, website and default API server.


### PR DESCRIPTION
Telescope project doesn't exist anymore and link is dead, see https://vulcan-docs.vercel.app/ for the latest version (I am the current maintainer of this project)