### PR TITLE
Add Uni-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for a curated list of packages and resources.
 * [Hackathon Starter](https://github.com/sahat/hackathon-starter) - A boilerplate for Node.js web applications.
 * [Node-RED](https://github.com/node-red/node-red) - A visual tool for wiring the Internet of Things
 * [nscm](https://github.com/nodesource/nscm) - An open-source CLI tool for working with NodeSource Certified Modules
-* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) ([npm](https://www.npmjs.com/package/@zenalexa/unicli)) - Universal CLI for AI agents with 756 commands across 167 sites. Self-repairing YAML adapters, auto-JSON output, and browser automation via CDP.
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) ([npm](https://www.npmjs.com/package/@zenalexa/unicli)) - Universal CLI for AI agents with 1,458 commands across 238 sites. Self-repairing YAML adapters, auto-JSON output, and browser automation via CDP.
 
 **Electron apps**
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ for a curated list of packages and resources.
 * [Hackathon Starter](https://github.com/sahat/hackathon-starter) - A boilerplate for Node.js web applications.
 * [Node-RED](https://github.com/node-red/node-red) - A visual tool for wiring the Internet of Things
 * [nscm](https://github.com/nodesource/nscm) - An open-source CLI tool for working with NodeSource Certified Modules
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) ([npm](https://www.npmjs.com/package/@zenalexa/unicli)) - Universal CLI for AI agents with 756 commands across 167 sites. Self-repairing YAML adapters, auto-JSON output, and browser automation via CDP.
 
 **Electron apps**
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for a curated list of packages and resources.
 * [Hackathon Starter](https://github.com/sahat/hackathon-starter) - A boilerplate for Node.js web applications.
 * [Node-RED](https://github.com/node-red/node-red) - A visual tool for wiring the Internet of Things
 * [nscm](https://github.com/nodesource/nscm) - An open-source CLI tool for working with NodeSource Certified Modules
-* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) ([npm](https://www.npmjs.com/package/@zenalexa/unicli)) - Universal CLI for AI agents with 1,458 commands across 238 sites. Self-repairing YAML adapters, auto-JSON output, and browser automation via CDP.
+* [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) ([npm](https://www.npmjs.com/package/@zenalexa/unicli)) - Universal CLI for AI agents exposing web, desktop, and Electron apps as deterministic commands. Self-repairing YAML adapters, auto-JSON output, and browser automation via CDP.
 
 **Electron apps**
 


### PR DESCRIPTION
[Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) is a universal CLI for AI agents built with Node.js/TypeScript. 756 commands across 167 sites with self-repairing YAML adapters, auto-JSON output, and browser automation via raw CDP. Apache-2.0.

Added to the **Developers** section.